### PR TITLE
Passes a stream to HTTPUtils to parse

### DIFF
--- a/lib/rack_fake_s3/file_store.rb
+++ b/lib/rack_fake_s3/file_store.rb
@@ -161,7 +161,7 @@ module RackFakeS3
         if boundary
           boundary = WEBrick::HTTPUtils::dequote(boundary)
           filedata = WEBrick::HTTPUtils::parse_form_data(
-            request.body.respond_to?(:read) ? request.body.read : request.body
+            request.body.respond_to?(:read) ? request.body.read : request.body,
             boundary
           )
           raise HTTPStatus::BadRequest if filedata['file'].empty?


### PR DESCRIPTION
Uploading files was borking with this error:

```
undefined method `each_line' for #<Unicorn::TeeInput:0x007f85abbba188>
/opt/rubies/1.9.3+envato4/lib/ruby/1.9.1/webrick/httputils.rb:312:in `parse_form_data'
/opt/rubies/1.9.3+envato4/lib/ruby/gems/1.9.1/gems/rack_fake_s3-0.2.3/lib/rack_fake_s3/file_store.rb:163:in `store_object'
/opt/rubies/1.9.3+envato4/lib/ruby/gems/1.9.1/gems/rack_fake_s3-0.2.3/lib/rack_fake_s3/server.rb:197:in `do_POST'
/opt/rubies/1.9.3+envato4/lib/ruby/gems/1.9.1/gems/rack_fake_s3-0.2.3/lib/rack_fake_s3/server.rb:74:in `perform'
/opt/rubies/1.9.3+envato4/lib/ruby/gems/1.9.1/gems/rack_fake_s3-0.2.3/lib/rack_fake_s3/server.rb:63:in `call'
```
